### PR TITLE
Fixed "digest already called" when building

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -34,9 +34,7 @@ async function getRemoteImage(node, collection, options) {
 
     await imageDownload(node[options.sourceField]).then(buffer => {
         
-        const crypto = require('crypto');
         for (let i = 0; i < 5; i++) {
-            const hash = crypto.createHash('sha256');
             hash.update(node[options.sourceField] + i);
             const type = imageType(buffer);
             var targetFileName = hash.digest('hex');

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -34,16 +34,21 @@ async function getRemoteImage(node, collection, options) {
 
     await imageDownload(node[options.sourceField]).then(buffer => {
         
-        hash.update(node[options.sourceField]);
-        const type = imageType(buffer);
-        var targetFileName = hash.digest('hex');
-        const filePath = path.resolve('./', options.targetPath, `${targetFileName}.${type.ext}`)        
+        const crypto = require('crypto');
+        for (let i = 0; i < 5; i++) {
+            const hash = crypto.createHash('sha256');
+            hash.update(node[options.sourceField] + i);
+            const type = imageType(buffer);
+            var targetFileName = hash.digest('hex');
+            const filePath = path.resolve('./', options.targetPath, `${targetFileName}.${type.ext}`)        
 
-        fs.writeFile(filePath, buffer, (err) => console.log(err ? err : ''));
+            fs.writeFile(filePath, buffer, (err) => console.log(err ? err : ''));
 
-        node[options.targetField] = filePath;
+            node[options.targetField] = filePath;
 
-        collection.updateNode(node);
+            collection.updateNode(node);
+        }
+        
     });
 
 }

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -34,7 +34,7 @@ async function getRemoteImage(node, collection, options) {
 
     await imageDownload(node[options.sourceField]).then(buffer => {
         
-        for (let i = 0; i < 5; i++) {
+        for (let i = 0; i < 1; i++) {
             hash.update(node[options.sourceField] + i);
             const type = imageType(buffer);
             var targetFileName = hash.digest('hex');


### PR DESCRIPTION
Fixes "digest already called" error preventing the plugin working with the Ghost source (as per our chat on discord).