### PR TITLE
Add configuration options to allow HTTP and download images from local network

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -137,7 +137,7 @@ class ImageDownloader {
 
     async getRemoteImage ( node, fieldType, options ) {
         // Set some defaults
-        const { cache = true, original = false, targetPath = 'src/assets/remoteImages', sourceField } = options
+        const { cache = true, original = false, forceHttps = true, downloadFromLocalNetwork = false, targetPath = 'src/assets/remoteImages', sourceField } = options
 
         const imageSources = (fieldType === 'string') ? [get(node, sourceField)] : get(node, sourceField)
 
@@ -145,7 +145,7 @@ class ImageDownloader {
             imageSources.map( async imageSource => {
 
                 // Check if we have a local file as source
-                var isLocal = validate({ imageSource: imageSource }, { imageSource: { url: true } })
+                var isLocal = validate({ imageSource: imageSource }, { imageSource: { url: { allowLocal: downloadFromLocalNetwork } } })
 
                 // If this is the case, we can stop here and re-using the existing image
                 if( isLocal ) {
@@ -153,7 +153,7 @@ class ImageDownloader {
                 }
 
                 // Normalize URL, and extract the pathname, to be used for the original filename if required
-                imageSource = normalizeUrl(imageSource, { 'forceHttps': true })
+                imageSource = normalizeUrl(imageSource, { 'forceHttps': forceHttps })
                 const { pathname } = new URL(imageSource)
                 // Parse the path to get the existing name, dir, and ext
                 let { name, dir, ext } = path.parse(pathname)


### PR DESCRIPTION
Hi, I added two new configuration options to the plugin because I needed to download images from a CMS that is located on a host in the local network (whithout using HTTPS).
In the current version of the plugin, URLs that contain a private IP address or the hostname "localhost" are ignored, i.e. images are not downloaded. Also, all URLs are rewritten from "http://example.com" to "https://example.com".

So I added these new options:

| Property                 | Type      | Required | Default | Description                                                               |
| ------------------------ | --------- | -------- | ------- | ------------------------------------------------------------------------- |
| forceHttps               | `Boolean` | No       | `true`  | Enable/disable rewrite from http to https                                 |
| downloadFromLocalNetwork | `Boolean` | No       | `false` | Download images from local network (e.g. private ip address or localhost) |

The default values are chosen in a way so that the behaviour of the plugin stays the same as before if the options are omitted.

I think other people may run into the same problem, so I created this PR.
