### PR TITLE
Added schemaType option

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -101,7 +101,11 @@ class ImageDownloader {
 
     generateSchemaType(addSchemaTypes, fieldType) {
 
-        const schemaType = (fieldType === 'string') ? 'Image' : '[Images]'
+        const schemaType =
+        fieldType === 'string' ||
+        !!(this.options.schemaType && this.options.schemaType === 'Image')
+            ? 'Image'
+            : '[Images]'
 
         addSchemaTypes(`
             type Images {


### PR DESCRIPTION
Users can now initialize the schemaType to be of type Image. This addresses an edge case when using the plugin with Sanity as noted in #20. In most cases, this option will not be necessary since the plugin deduces the schemaType based off the sourceField option.  

The option is optional and can be configured as shown below:

```
{
  use: '@noxify/gridsome-plugin-remote-image',
  options: {
    cache: false,
    typeName: 'SanityImageAsset',      
    schemaType: 'Image',
    sourceField: 'url',
    targetField: 'localFile',
    targetPath: 'src/assets/sanity/images',
  },
},
```