### PR TITLE
Downloading images in parallel could cause some webhosts to return HTTP 503

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -124,7 +124,9 @@ class ImageDownloader {
     async updateNodes(api, fieldType, plugin) {
         const collection = api._app.store.getCollection(plugin.options.typeName)
 
-        collection.data().forEach(async node => {
+
+        collection.data().reduce(async (prev, node) => {
+            await prev
             if (get(node,plugin.options.sourceField)) {
                 const imagePaths = await plugin.getRemoteImage(node, fieldType, plugin.options)
 
@@ -136,7 +138,8 @@ class ImageDownloader {
 
                 collection.updateNode(node)
             }
-        })
+            return Promise.resolve()
+        }, Promise.resolve())
     }
 
     async getRemoteImage ( node, fieldType, options ) {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -125,7 +125,7 @@ class ImageDownloader {
         const collection = api._app.store.getCollection(plugin.options.typeName)
 
 
-        collection.data().reduce(async (prev, node) => {
+        await collection.data().reduce(async (prev, node) => {
             await prev
             if (get(node,plugin.options.sourceField)) {
                 const imagePaths = await plugin.getRemoteImage(node, fieldType, plugin.options)


### PR DESCRIPTION
The plugins downloads all images using an async forEach, which means all the images are downloaded in parallel. My source contains hundreds of images, sending all those requests at the same time causes my webhost to respond with `503 Service Unavailable` to most of them.
I think it would be better to wait for each image download to be completed before sending the next request. This can be done using a reduce method instead of the forEach.