### PR TITLE
Added support for urlPrefix

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -149,7 +149,8 @@ class ImageDownloader {
             original = false, 
             forceHttps = false, 
             normalizeProtocol = true, 
-            defaultProtocol = 'http:', 
+            defaultProtocol = 'http:',
+            urlPrefix = '', 
             downloadFromLocalNetwork = false, 
             targetPath = 'src/assets/remoteImages', 
             sourceField 
@@ -159,6 +160,11 @@ class ImageDownloader {
 
         return Promise.all(
             imageSources.map( async imageSource => {
+
+                // If a URL prefix is provided, add it
+                if ( urlPrefix ) {
+                    imageSource = urlPrefix.concat(imageSource);
+                }
 
                 try {
                 // Normalize URL, and extract the pathname, to be used for the original filename if required


### PR DESCRIPTION
Many CMSs (including Strapi) serve up non-absolute URLS
to the API (in the format '/image-url.jpg'). Currently the plugin
treats these as local images.

With the addition of a 'urlPrefix' config option, a full domain can be
provided which will be added to the target source URL before attempting
to download.

Note that documentation is obviously not updated as not in this repo. 

This would be a useful feature for me and my team. 